### PR TITLE
Store message clients in the database.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -187,7 +187,7 @@ function pollServer(options, callback) {
       request.get({
         url: options.endpoint,
         httpSignature: {
-          key: results.getPrivateKey.privateKeyPem,
+          key: results.getPrivateKey,
           keyId: options.publicKeyId,
           headers: ['date', 'host', 'request-line']
         },

--- a/lib/client.js
+++ b/lib/client.js
@@ -212,7 +212,7 @@ function pollServer(options, callback) {
       request.get({
         url: client.endpoint,
         httpSignature: {
-          key: results.getPrivateKey,
+          key: results.getPrivateKey.privateKeyPem,
           keyId: client.publicKeyId,
           headers: ['date', 'host', 'request-line']
         },

--- a/lib/client.js
+++ b/lib/client.js
@@ -58,6 +58,7 @@ bedrock.events.on('bedrock-mongodb.ready', function(callback) {
         var meta = {};
         meta.created = now;
         meta.updated = now;
+        meta.recentPollErrorCount = 0;
         var record = {
           id: database.hash(client.id),
           meta: meta,
@@ -78,14 +79,15 @@ bedrock.events.on('bedrock-mongodb.ready', function(callback) {
     }],
     startClients: ['getClients', function(callback, results) {
       var clients = results.getClients;
-      console.log("Got clients, defining", clients);
       async.each(clients, function(client, callback) {
         var jobId = createJobId(client);
         var endpoint = client.endpoint;
         var privateKeyPem = client.privateKeyPem;
         var publicKeyId = client.publicKeyId;
-        var strictSSL = !('strictSSL' in client) ?
-          true : !!client.strictSSL;
+        var strictSSL = ('strictSSL' in client) ?
+          !!client.strictSSL : true;
+
+        // define function to run as job later
         var fn = function(job, callback) {
           var id = client.id;
           async.auto({
@@ -138,8 +140,6 @@ api.start = function(client, callback) {
     priority: 0,
     concurrency: 1
   };
-  console.log("++++++++++++++++++++++++++++++++++++++++++");
-  console.log("Creating client with schedule", jobSchedule);
   // TODO: What happens if a job unschedules but doesn't schedule?
   scheduler.unschedule({id: jobId}, function(err) {
     if(err) {
@@ -180,35 +180,37 @@ api._pollServer = function(options, callback) {
 };
 
 function pollServer(options, callback) {
-  console.log("Poll server called with options", options);
   var client = options.client;
-  var retries = 0;
-  var maxRetries = config['messages-client'].maxMessageRetrievalRetries;
-  var failedToRetrieveMessageEvent = {
-    type: 'messageClient.failedToRetrieveMessage',
-    details: {
-      endpoint: client.endpoint
-    }
-  };
+  var jobId = createJobId(client);
+  var pollErrorCount;
+
   async.auto({
-    getPrivateKey: function(callback) {
+    getClient: function(callback) {
+      database.collections.messageClient.findOne(
+        {id: database.hash(client.id)}, {}, function(err, record) {
+          pollErrorCount = record.meta.recentPollErrorCount;
+          callback(null, record);
+        });
+    },
+    // TODO: Use SSM/HSM to get private key
+    getPrivateKey: function(callback, result) {
       brKey.getPublicKey({id: client.publicKeyId}, null,
         function(err, publicKey, meta, privateKey) {
-          if(!privateKey) {
-            return callback(new BedrockError(
-            'Contacting server with no private key configured: ' +
-              client.endpoint,
-            'SigningFailure', {statusCode: 400}
-            ));
+          if(!privateKey || err) {
+            return handlePollServerError({
+              client: client,
+              jobId: jobId,
+              error: new BedrockError(
+                'The server could not be contacted: ' + client.endpoint,
+                'PollServerError', {},
+                err || new Error('Private key not found.')),
+              pollErrorCount: pollErrorCount
+            }, callback);
           }
           callback(err, privateKey);
         });
     },
-    poll: ['getPrivateKey', function(callback, results) {
-      console.log("Private key");
-      console.log(results.getPrivateKey);
-      console.log("Public key id");
-      console.log(client.publicKeyId);
+    poll: ['getPrivateKey', 'getClient', function(callback, results) {
       request.get({
         url: client.endpoint,
         httpSignature: {
@@ -220,34 +222,34 @@ function pollServer(options, callback) {
         strictSSL: client.strictSSL
       }, function(err, res, body) {
         if(err) {
-          retries++;
-          // The job will continue to retry contacting the endpoint, but it
-          // will only fire off one email event
-          if(retries === maxRetries) {
-            bedrock.events.emitLater(failedToRetrieveMessageEvent);
-          }
-          return callback(new BedrockError(
-            'The server could not be contacted: ' + client.endpoint,
-            'HttpError', {
-            httpError: err
-          }));
+          return handlePollServerError({
+            client: client,
+            jobId: jobId,
+            error: new BedrockError(
+              'The server could not be contacted: ' + client.endpoint,
+              'PollServerError', {}, err),
+            pollErrorCount: pollErrorCount
+          }, callback);
         }
         if(res.statusCode !== 200) {
-          retries++;
-          // The job will continue to retry contacting the endpoint, but it
-          // will only fire off one email event
-          if(retries === maxRetries) {
-            bedrock.events.emitLater(failedToRetrieveMessageEvent);
-          }
-          // FIXME: fix-up error message
-          return callback(new BedrockError(
-            'The server responded with an error: ' + client.endpoint,
-            'HttpError', {
-              statusCode: res.statusCode,
-              details: body
-            }));
+          return handlePollServerError({
+            client: client,
+            jobId: jobId,
+            error: new BedrockError(
+              'The server could not be contacted: ' + client.endpoint,
+              'PollServerError', {
+                httpStatusCode: res.statusCode,
+                details: body
+              }),
+            pollErrorCount: pollErrorCount
+          }, callback);
         }
-        callback(null, body);
+
+        database.collections.messageClient.update({
+          id: database.hash(client.id)
+        }, {$set: {'meta.recentPollErrorCount': 0}}, singleUpdate, function(err, result) {
+          callback(err, body);
+        });
       });
     }],
     process: ['poll', function(callback, results) {
@@ -259,6 +261,7 @@ function pollServer(options, callback) {
       // FIXME: possibly use template configured by top level module to
       // describe message subject and body
       // FIXME: perform some validation on the link for safety?
+      // FIXME: the message content should come from a file or template
       var messages = results.poll.map(function(message) {
         var newMessage = message;
         if(message.type === 'CredentialNotification') {
@@ -267,7 +270,6 @@ function pollServer(options, callback) {
           newMessage.subject = 'A credential is available for pick-up';
           if(message.content.potentialAction != null &&
             message.content.potentialAction.length > 0) {
-
             newMessage.content.body = 'Click <a href="' +
               message.content.potentialAction[0].target.urlTemplate +
               '">this link</a> to accept the credential.';
@@ -279,6 +281,56 @@ function pollServer(options, callback) {
     }]
   }, function(err, results) {
     callback(err, results.process);
+  });
+}
+
+/**
+ * Helper function to handle errors in pollServer.
+ */
+function handlePollServerError(options, callback) {
+  var client = options.client;
+  var jobId = createJobId(client);
+  var error = options.error;
+  var pollErrorCount = options.pollErrorCount;
+  var maxPollErrorsBeforeNotify = config['messages-client'].maxPollErrorsBeforeNotify;
+
+  var singleUpdate = bedrock.util.extend(
+    {}, database.writeOptions, {upsert: false, multi: false});
+
+  var pollServerErrorEvent = {
+    type: 'messageClient.pollServerError',
+    details: {
+      endpoint: client.endpoint
+    }
+  };
+
+  return database.collections.messageClient.update({
+    id: database.hash(client.id)
+  }, {$inc: {'meta.recentPollErrorCount': 1}}, singleUpdate, function(err, result) {
+    if(err) {
+      return callback(err);
+    }
+    if(pollErrorCount + 1 === maxPollErrorsBeforeNotify) {
+      bedrock.events.emitLater(pollServerErrorEvent);
+      if(config['messages-client'].stopPollingAfterNotify) {
+        return scheduler.unschedule({id: jobId}, function(err) {
+          if(err) {
+            return callback(err);
+          }
+          database.collections.messageClient.update({
+            id: database.hash(client.id)
+          },
+          {$set: {'meta.recentPollErrorCount': 0}},
+          singleUpdate, function(err) {
+            if(err) {
+              return callback(err);
+            }
+            callback(error);
+          });
+        });
+      }
+    }
+    return callback(error);
   });
 }
 
@@ -346,7 +398,6 @@ api.get = function(actor, id, callback) {
           'NotFound',
           {id: id, httpStatusCode: 404, public: true}));
       }
-      console.log("Get returning client", record.client);
       callback(null, record.client, record.meta);
     }
   ], callback);

--- a/lib/client.js
+++ b/lib/client.js
@@ -11,6 +11,7 @@ var async = require('async');
 var bedrock = require('bedrock');
 var config = bedrock.config;
 var BedrockError = bedrock.util.BedrockError;
+var brKey = require('bedrock-key');
 var brMessages = require('bedrock-messages');
 var database = require('bedrock-mongodb');
 var request = require('request');
@@ -45,7 +46,6 @@ bedrock.events.on('bedrock-mongodb.ready', function(callback) {
       }], callback);
     }],
     insertClients: ['createIndexes', function(callback) {
-      console.log("Inserting clients");
       var clients = config['messages-client'].clients;
       async.each(clients, function(client, callback) {
         var now = Date.now();
@@ -170,11 +170,24 @@ function pollServer(options, callback) {
     }
   };
   async.auto({
-    poll: function(callback) {
+    getPrivateKey: function(callback) {
+      brKey.getPublicKey({id: options.publicKeyId}, null,
+        function(err, publicKey, meta, privateKey) {
+          if(!privateKey) {
+            return callback(new BedrockError(
+            'Contacting server with no private key configured: ' +
+              options.endpoint,
+            'SigningFailure', {statusCode: 400}
+            ));
+          }
+          callback(err, privateKey);
+        });
+    },
+    poll: ['getPrivateKey', function(callback, results) {
       request.get({
         url: options.endpoint,
         httpSignature: {
-          key: options.privateKeyPem,
+          key: results.getPrivateKey.privateKeyPem,
           keyId: options.publicKeyId,
           headers: ['date', 'host', 'request-line']
         },
@@ -211,7 +224,7 @@ function pollServer(options, callback) {
         }
         callback(null, body);
       });
-    },
+    }],
     process: ['poll', function(callback, results) {
       if(results.poll.length === 0) {
         return callback();

--- a/lib/client.js
+++ b/lib/client.js
@@ -7,6 +7,7 @@
 
 'use strict';
 
+var _ = require('lodash');
 var async = require('async');
 var bedrock = require('bedrock');
 var config = bedrock.config;
@@ -17,6 +18,10 @@ var database = require('bedrock-mongodb');
 var request = require('request');
 var scheduler = require('bedrock-jobs');
 var uuid = require('node-uuid').v4;
+
+var brIdentity = require('bedrock-identity');
+
+var PERMISSIONS = bedrock.config.permission.permissions;
 
 require('./config');
 
@@ -30,6 +35,7 @@ bedrock.events.on('bedrock.test.configure', function() {
   require('./test.config');
 });
 
+// TODO: Need validation on client objects
 bedrock.events.on('bedrock-mongodb.ready', function(callback) {
   if(!config['messages-client'].enable) {
     return callback();
@@ -67,35 +73,41 @@ bedrock.events.on('bedrock-mongodb.ready', function(callback) {
         });
       }, callback);
     }],
-    startClients: ['insertClients', function(callback) {
-      var interval = 1;
-      var clients = config['messages-client'].clients;
-      async.each(clients, function(clientOptions, callback) {
-        var jobId = createJobId(clientOptions.endpoint);
-        var endpoint = clientOptions.endpoint;
-        var privateKeyPem = clientOptions.privateKeyPem;
-        var publicKeyId = clientOptions.publicKeyId;
-        var strictSSL = !('strictSSL' in clientOptions) ?
-          true : !!clientOptions.strictSSL;
+    getClients: ['insertClients', function(callback, results) {
+      api.getAll(null, callback);
+    }],
+    startClients: ['getClients', function(callback, results) {
+      var clients = results.getClients;
+      console.log("Got clients, defining", clients);
+      async.each(clients, function(client, callback) {
+        var jobId = createJobId(client);
+        var endpoint = client.endpoint;
+        var privateKeyPem = client.privateKeyPem;
+        var publicKeyId = client.publicKeyId;
+        var strictSSL = !('strictSSL' in client) ?
+          true : !!client.strictSSL;
         var fn = function(job, callback) {
-          var options = {
-            job: job,
-            endpoint: endpoint,
-            privateKeyPem: privateKeyPem,
-            publicKeyId: publicKeyId,
-            strictSSL: strictSSL
-          };
-          pollServer(options, function(err, results) {
-            if(err) {
-              return callback(err);
-            }
-            callback();
-          });
+          var id = client.id;
+          async.auto({
+            getClient: function(callback) {
+              api.get(null, id, function(err, results) {
+                callback(err, results);
+              });
+            },
+            poll: ['getClient', function(callback, results) {
+              var client = results.getClient;
+              var options = {
+                job: job,
+                client: client
+              };
+              pollServer(options, callback);
+            }]
+          }, callback);
         };
 
         scheduler.define(jobId, fn);
 
-        api.start(endpoint, interval, callback);
+        api.start(client, callback);
       }, callback);
     }]
   }, callback);
@@ -110,24 +122,31 @@ bedrock.events.on('bedrock-mongodb.ready', function(callback) {
  * @param interval the number of minutes to wait between polling
  * the endpoint (e.g. 1, 5, or 10)
  */
-api.start = function(endpoint, interval, callback) {
-  // TODO: Where validation of the interval being equal to 1,5, or 10 be located
-  var jobId = createJobId(endpoint);
+api.start = function(client, callback) {
+  if(!client.interval || !client.id) {
+    return callback(new BedrockError(
+      'Could not start the client.',
+      'SchedulingFailure',
+      {id: client.id, interval: client.interval}
+    ));
+  }
+  var jobId = createJobId(client);
   var jobSchedule = {
     id: jobId,
     type: jobId,
-    schedule: 'R/PT' + interval + 'M',
+    schedule: 'R/PT' + client.interval + 'M',
     priority: 0,
     concurrency: 1
   };
-
+  console.log("++++++++++++++++++++++++++++++++++++++++++");
+  console.log("Creating client with schedule", jobSchedule);
   // TODO: What happens if a job unschedules but doesn't schedule?
   scheduler.unschedule({id: jobId}, function(err) {
     if(err) {
       return callback(new BedrockError(
         'Could not start the client.',
         'UnschedulingFailure',
-        {endpoint: endpoint, interval: interval}
+        {id: client.id, interval: client.interval}
       ));
     }
 
@@ -136,7 +155,7 @@ api.start = function(endpoint, interval, callback) {
         return callback(new BedrockError(
           'Could not start the client.',
           'SchedulingFailure',
-          {endpoint: endpoint, interval: interval}
+          {id: client.id, interval: client.interval}
         ));
       }
 
@@ -146,10 +165,10 @@ api.start = function(endpoint, interval, callback) {
 };
 
 /*
- * @param endpoint The endpoint used to create the jobId
+ * @param client The client used to create the jobId
  */
-function createJobId(endpoint) {
-  return 'brMessagesClient.getMessages.' + endpoint;
+function createJobId(client) {
+  return 'brMessagesClient.getMessages.' + client.id;
 }
 
 // exposed for testing
@@ -161,22 +180,24 @@ api._pollServer = function(options, callback) {
 };
 
 function pollServer(options, callback) {
+  console.log("Poll server called with options", options);
+  var client = options.client;
   var retries = 0;
   var maxRetries = config['messages-client'].maxMessageRetrievalRetries;
   var failedToRetrieveMessageEvent = {
     type: 'messageClient.failedToRetrieveMessage',
     details: {
-      endpoint: options.endpoint
+      endpoint: client.endpoint
     }
   };
   async.auto({
     getPrivateKey: function(callback) {
-      brKey.getPublicKey({id: options.publicKeyId}, null,
+      brKey.getPublicKey({id: client.publicKeyId}, null,
         function(err, publicKey, meta, privateKey) {
           if(!privateKey) {
             return callback(new BedrockError(
             'Contacting server with no private key configured: ' +
-              options.endpoint,
+              client.endpoint,
             'SigningFailure', {statusCode: 400}
             ));
           }
@@ -184,15 +205,19 @@ function pollServer(options, callback) {
         });
     },
     poll: ['getPrivateKey', function(callback, results) {
+      console.log("Private key");
+      console.log(results.getPrivateKey);
+      console.log("Public key id");
+      console.log(client.publicKeyId);
       request.get({
-        url: options.endpoint,
+        url: client.endpoint,
         httpSignature: {
           key: results.getPrivateKey,
-          keyId: options.publicKeyId,
+          keyId: client.publicKeyId,
           headers: ['date', 'host', 'request-line']
         },
         json: true,
-        strictSSL: options.strictSSL
+        strictSSL: client.strictSSL
       }, function(err, res, body) {
         if(err) {
           retries++;
@@ -202,7 +227,7 @@ function pollServer(options, callback) {
             bedrock.events.emitLater(failedToRetrieveMessageEvent);
           }
           return callback(new BedrockError(
-            'The server could not be contacted: ' + options.endpoint,
+            'The server could not be contacted: ' + client.endpoint,
             'HttpError', {
             httpError: err
           }));
@@ -216,7 +241,7 @@ function pollServer(options, callback) {
           }
           // FIXME: fix-up error message
           return callback(new BedrockError(
-            'The server responded with an error: ' + options.endpoint,
+            'The server responded with an error: ' + client.endpoint,
             'HttpError', {
               statusCode: res.statusCode,
               details: body
@@ -256,3 +281,113 @@ function pollServer(options, callback) {
     callback(err, results.process);
   });
 }
+
+/**
+ * Retrieves all clients matching the given query.
+ *
+ * @param actor the Identity performing the action.
+ * @param [query] the optional query to use (default: {}).
+ * @param [fields] optional fields to include or exclude (default: {}).
+ * @param [options] options (eg: 'sort', 'limit').
+ * @param callback(err, records) called once the operation completes.
+ */
+api.getAll = function(actor, query, fields, options, callback) {
+  // handle args
+  if(typeof query === 'function') {
+    callback = query;
+    query = null;
+    fields = null;
+  } else if(typeof fields === 'function') {
+    callback = fields;
+    fields = null;
+  } else if(typeof options === 'function') {
+    callback = options;
+    options = null;
+  }
+
+  query = query || {};
+  fields = fields || {};
+  options = options || {};
+  async.waterfall([
+    function(callback) {
+      brIdentity.checkPermission(
+        actor, PERMISSIONS.MESSAGE_CLIENT_ADMIN, callback);
+    },
+    function(callback) {
+      database.collections.messageClient.find(
+        query, fields, options).toArray(function(err, results) {
+          callback(err, _.map(results, 'client'));
+        });
+    }
+  ], callback);
+};
+
+/**
+ * Retrieves a message client.
+ *
+ * @param actor the Identity performing the action.
+ * @param id the ID of the Client to retrieve.
+ * @param callback(err, client, meta) called once the operation completes.
+ */
+api.get = function(actor, id, callback) {
+  async.waterfall([
+    function(callback) {
+      brIdentity.checkPermission(
+        actor, PERMISSIONS.MESSAGE_CLIENT_ADMIN, callback);
+    },
+    function(callback) {
+      database.collections.messageClient.findOne(
+        {id: database.hash(id)}, {}, callback);
+    },
+    function(record, callback) {
+      if(!record) {
+        return callback(new BedrockError(
+          'Client not found.',
+          'NotFound',
+          {id: id, httpStatusCode: 404, public: true}));
+      }
+      console.log("Get returning client", record.client);
+      callback(null, record.client, record.meta);
+    }
+  ], callback);
+};
+
+api.update = function(actor, client, options, callback) {
+  if(typeof options === 'function') {
+    callback = options;
+    options = {};
+  }
+  options = bedrock.util.extend({}, options);
+  async.auto({
+    checkPermission: function(callback) {
+      brIdentity.checkPermission(
+        actor, PERMISSIONS.MESSAGE_CLIENT_ADMIN, callback);
+    },
+    update: ['checkPermission', function(callback) {
+      // build a database update
+      var update = database.buildUpdate(client, 'client', {
+        include: [
+          'client.id',
+          'client.label',
+          'client.endpoint',
+          'client.interval',
+          'client.publicKeyId',
+          'client.strictSSL'
+        ]
+      });
+      database.collections.messageClient.update(
+        {id: database.hash(client.id)},
+        {$set: update}, database.writeOptions, function(err, results) {
+          if(results.result.n === 0) {
+            return callback(new BedrockError(
+              'Could not update Client. Client not found.',
+              'NotFound'));
+          }
+          callback();
+        });
+    }],
+    restart: ['update', function(callbacK) {
+      api.start(client, callback);
+    }]
+  }, callback);
+};

--- a/lib/client.js
+++ b/lib/client.js
@@ -12,6 +12,7 @@ var bedrock = require('bedrock');
 var config = bedrock.config;
 var BedrockError = bedrock.util.BedrockError;
 var brMessages = require('bedrock-messages');
+var database = require('bedrock-mongodb');
 var request = require('request');
 var scheduler = require('bedrock-jobs');
 var uuid = require('node-uuid').v4;
@@ -32,35 +33,72 @@ bedrock.events.on('bedrock-mongodb.ready', function(callback) {
   if(!config['messages-client'].enable) {
     return callback();
   }
-  var interval = 1;
-  config['messages-client'].clients
-    .forEach(function(clientOptions) {
-      var jobId = createJobId(clientOptions.endpoint);
-      var endpoint = clientOptions.endpoint;
-      var privateKeyPem = clientOptions.privateKeyPem;
-      var publicKeyId = clientOptions.publicKeyId;
-      var strictSSL = !('strictSSL' in clientOptions) ?
-        true : !!clientOptions.strictSSL;
-      var fn = function(job, callback) {
-        var options = {
-          job: job,
-          endpoint: endpoint,
-          privateKeyPem: privateKeyPem,
-          publicKeyId: publicKeyId,
-          strictSSL: strictSSL
+  async.auto({
+    openCollections: function(callback) {
+      database.openCollections(['messageClient'], callback);
+    },
+    createIndexes: ['openCollections', function(callback) {
+      database.createIndexes([{
+        collection: 'messageClient',
+        fields: {id: 1},
+        options: {unique: true, background: false}
+      }], callback);
+    }],
+    insertClients: ['createIndexes', function(callback) {
+      console.log("Inserting clients");
+      var clients = config['messages-client'].clients;
+      async.each(clients, function(client, callback) {
+        var now = Date.now();
+        var meta = {};
+        meta.created = now;
+        meta.updated = now;
+        var record = {
+          id: database.hash(client.id),
+          meta: meta,
+          client: client
         };
-        pollServer(options, function(err, results) {
-          if(err) {
-            return callback(err);
+        database.collections.messageClient.insert(
+        record, database.writeOptions, function(err, result) {
+          if(err && database.isDuplicateError(err)) {
+            // Don't fail on duplicates
+            return callback();
           }
-          callback();
+          callback(err);
         });
-      };
+      }, callback);
+    }],
+    startClients: ['insertClients', function(callback) {
+      var interval = 1;
+      var clients = config['messages-client'].clients;
+      async.each(clients, function(clientOptions, callback) {
+        var jobId = createJobId(clientOptions.endpoint);
+        var endpoint = clientOptions.endpoint;
+        var privateKeyPem = clientOptions.privateKeyPem;
+        var publicKeyId = clientOptions.publicKeyId;
+        var strictSSL = !('strictSSL' in clientOptions) ?
+          true : !!clientOptions.strictSSL;
+        var fn = function(job, callback) {
+          var options = {
+            job: job,
+            endpoint: endpoint,
+            privateKeyPem: privateKeyPem,
+            publicKeyId: publicKeyId,
+            strictSSL: strictSSL
+          };
+          pollServer(options, function(err, results) {
+            if(err) {
+              return callback(err);
+            }
+            callback();
+          });
+        };
 
-      scheduler.define(jobId, fn);
+        scheduler.define(jobId, fn);
 
-      api.start(endpoint, interval, callback);
-    });
+        api.start(endpoint, interval, callback);
+      }, callback);
+    }]
+  }, callback);
 });
 
 /*
@@ -116,52 +154,6 @@ function createJobId(endpoint) {
 
 // exposed for testing
 api._createJobId = createJobId;
-
-// MessageClient class is deprecated
-
-// FIXME: replace private key information with a signing service
-// private key should be kept safe
-api.MessageClient = function(options) {
-  this.endpoint = options.endpoint;
-  this.privateKeyPem = options.privateKeyPem;
-  this.publicKeyId = options.publicKeyId;
-  this.jobId = uuid();
-  if(!('strictSSL' in options)) {
-    this.strictSSL = true;
-  } else {
-    this.strictSSL = !!options.strictSSL;
-  }
-  // TODO: implement this option
-  // this.pollInterval = options.pollInterval;
-  config.scheduler.jobs.push({
-    id: this.jobId,
-    type: this.jobId,
-    // repeat forever, run every minute
-    schedule: 'R/PT1M',
-    // no special priority
-    priority: 0,
-    concurrency: 1
-  });
-};
-
-api.MessageClient.prototype.start = function() {
-  var self = this;
-  scheduler.define(self.jobId, function(job, callback) {
-    var options = {
-      job: job,
-      endpoint: self.endpoint,
-      privateKeyPem: self.privateKeyPem,
-      publicKeyId: self.publicKeyId,
-      strictSSL: self.strictSSL
-    };
-    pollServer(options, function(err, results) {
-      if(err) {
-        return callback(err);
-      }
-      callback(null);
-    });
-  });
-};
 
 // exposed for testing
 api._pollServer = function(options, callback) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -5,6 +5,7 @@
 var config = require('bedrock').config;
 var path = require('path');
 
-config['messages-client'] = {};
-config['messages-client'].clients = [];
-config['messages-client'].maxMessageRetrievalRetries = 3;
+config['messages-client'] = config['messages-client'] || {};
+config['messages-client'].clients = config['messages-client'].clients || [];
+config['messages-client'].maxMessageRetrievalRetries =
+  config['messages-client'].maxMessageRetrievalRetries || 3;

--- a/lib/config.js
+++ b/lib/config.js
@@ -7,8 +7,9 @@ var path = require('path');
 
 config['messages-client'] = config['messages-client'] || {};
 config['messages-client'].clients = config['messages-client'].clients || [];
-config['messages-client'].maxMessageRetrievalRetries =
-  config['messages-client'].maxMessageRetrievalRetries || 3;
+config['messages-client'].maxPollErrorsBeforeNotify =
+  config['messages-client'].maxPollErrorsBeforeNotify || 3;
+config['messages-client'].stopPollingAfterNotify = true;
 
 var permissions = config.permission.permissions;
 permissions.MESSAGE_CLIENT_ADMIN = {

--- a/lib/config.js
+++ b/lib/config.js
@@ -9,3 +9,10 @@ config['messages-client'] = config['messages-client'] || {};
 config['messages-client'].clients = config['messages-client'].clients || [];
 config['messages-client'].maxMessageRetrievalRetries =
   config['messages-client'].maxMessageRetrievalRetries || 3;
+
+var permissions = config.permission.permissions;
+permissions.MESSAGE_CLIENT_ADMIN = {
+  id: 'MESSAGE_CLIENT_ADMIN',
+  label: 'Message Client Administration',
+  comment: 'Required to administer Message Clients.'
+};

--- a/tests/01-api.js
+++ b/tests/01-api.js
@@ -21,7 +21,7 @@ var mockData = require('./mock.data');
 var store = database.collections.messages;
 var scheduler = require('bedrock-jobs');
 
-describe.only('bedrock-messages-client API requests', function() {
+describe('bedrock-messages-client API requests', function() {
   before('Prepare the database', function(done) {
     helpers.prepareDatabase(mockData, done);
   });

--- a/tests/01-api.js
+++ b/tests/01-api.js
@@ -21,7 +21,13 @@ var mockData = require('./mock.data');
 var store = database.collections.messages;
 var scheduler = require('bedrock-jobs');
 
-describe('bedrock-messages-client API requests', function() {
+describe.only('bedrock-messages-client API requests', function() {
+  before('Prepare the database', function(done) {
+    helpers.prepareDatabase(mockData, done);
+  });
+  after('Remove test data', function(done) {
+    helpers.removeCollections(done);
+  });
   describe('pollMessagesServer Function', function() {
     // NOTE: the tests in the block are designed to be run in series
     describe('polls a single server for new messages', function() {
@@ -122,7 +128,7 @@ describe('bedrock-messages-client API requests', function() {
     });
   });
 
-  describe.only('start API', function() {
+  describe('start API', function() {
     before(function(done) {
       helpers.removeCollections(done);
     });

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -134,7 +134,8 @@ api.prepareDatabase = function(mockData, callback) {
 };
 
 api.removeCollections = function(callback) {
-  var collectionNames = ['messages', 'identity', 'publicKey', 'job'];
+  var collectionNames = ['messages', 'identity', 'publicKey', 'job',
+    'messageClient'];
   database.openCollections(collectionNames, function(err) {
     async.each(collectionNames, function(collectionName, callback) {
       database.collections[collectionName].find({}, callback);

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -137,7 +137,7 @@ api.removeCollections = function(callback) {
   var collectionNames = ['messages', 'identity', 'publicKey', 'job'];
   database.openCollections(collectionNames, function(err) {
     async.each(collectionNames, function(collectionName, callback) {
-      database.collections[collectionName].remove({}, callback);
+      database.collections[collectionName].find({}, callback);
     }, function(err) {
       callback(err);
     });
@@ -152,7 +152,7 @@ function insertTestData(mockData, callback) {
         brIdentity.insert(null, identity.identity, callback);
       },
       function(callback) {
-        brKey.addPublicKey(null, identity.keys.publicKey, callback);
+        brKey.addPublicKey(null, identity.keys.publicKey, identity.keys.privateKey, callback);
       }
     ], callback);
   }, function(err) {


### PR DESCRIPTION
Storing client options in the database now -- added an "id" field to clients that can be configured, to ensure uniqueness.

We are storing the client's private key in the DB -- is this ok?

@mattcollier I removed the MessageClient class -- a note said it was deprecated so I just changed us to the configure only option and updated dependencies accordingly -- there aren't any traces of it anymore, that ok?